### PR TITLE
Use the graceful leave behaviour in rtc-signal

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ module.exports = function(socket, opts) {
   };
 
   signaller.leave = signaller.close = function() {
+    // Apply the default leave behaviour
+    signaller._leave();
+    // Close the socket
     return socket && socket.disconnect();
   };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rtc-io/rtc-signaller-socket.io",
   "dependencies": {
-    "rtc-signal": "^1.2.1"
+    "rtc-signal": "^1.3.0"
   },
   "devDependencies": {
     "broth": "^1.1.1",


### PR DESCRIPTION
Updates to use `rtc-signal@1.3.0` and the graceful leave behaviour of sending a `/leave` message prior to disconnect. (see https://github.com/rtc-io/rtc-quickconnect/issues/81)
